### PR TITLE
Attempt to prevent execution of remote-loaded non-JS text

### DIFF
--- a/lib/node-yui3.js
+++ b/lib/node-yui3.js
@@ -294,7 +294,9 @@ YUI.include = function(file, cb) {
                 data += chunk;
             });
             response.addListener("end", function() {
-                loaderFn(null, data);
+                if (response.statusCode >= 200 && response.statusCode < 300) {
+                    loaderFn(null, data);
+                }
             });
         });
         if (request.end) {


### PR DESCRIPTION
Today I'm getting many YQL error returns that are HTML formatted pages. These errors are HTML pages with status code 999. Passing HTML into loaderFn as the source of the new function causes syntax errors which immediately halts node.

Rather than assume the response.headers['Content-Type'] is set correctly in such cases, check the status code which certainly ought to be set correctly. Anything in the 2xx's should be fair game while everything else should be considered unsafe.
