### PR TITLE
Prevent ever growing list of partials

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -174,7 +174,7 @@ YUI.add('express', function(Y) {
                 }
             }
             docType = YUI.docTypes[docType];
-            var parts = YUI.partials;
+            var parts = eY.clone(YUI.partials);
             if (locals.partials) {
                 locals.partials.forEach(function(p) {
                     parts.push(p);


### PR DESCRIPTION
Dave,

this patch fixes the ever growing list of partials when using locals.partials in view options. See http://gist.github.com/648187 for a test case.
