### PR TITLE
Apply substitutions to the whole DOM, not just the body

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -149,9 +149,6 @@ YUI.add('express', function(Y) {
             YUI._express[eY.id] = eY;
         };
         
-        if (locals.sub) {
-            content = eY.Lang.sub(content, locals.sub);
-        }
         if (locals.instance) {
             if (!options.isLayout) {
                 //TODO
@@ -203,6 +200,9 @@ YUI.add('express', function(Y) {
                 locals.after(eY, options, locals.partial);
             }
             html += eY.config.doc.outerHTML;
+            if (locals.sub) {
+              html = eY.Lang.sub(html, locals.sub);
+            }
             YUI._express[eY.id] = eY;
             YUI.cleanExpress();
             return html;


### PR DESCRIPTION
Hi Dave,

another small refinement. This patch allows you to run substitutions over the whole DOM tree, including head. Using a partial to set head & title you can now localize title, meta tags, etc with the same locals.sub object.
