### PR TITLE
Include substitute module

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -143,9 +143,9 @@ YUI.add('express', function(Y) {
         var eY, locals = options.locals;
         if (locals.instance) {
             eY = locals.instance;
-            eY.use('node');
+            eY.use('node', 'substitute');
         } else {
-            eY = YUI({ debug: DEBUG }).use('node');
+            eY = YUI({ debug: DEBUG }).use('node', 'substitute');
             YUI._express[eY.id] = eY;
         };
         
@@ -202,7 +202,7 @@ YUI.add('express', function(Y) {
             }
             html += eY.config.doc.outerHTML;
             if (locals.sub) {
-              html = eY.Lang.sub(html, locals.sub);
+              html = eY.substitute(html, locals.sub);
             }
             YUI._express[eY.id] = eY;
             YUI.cleanExpress();


### PR DESCRIPTION
Hi Dave,

having the substitute module available in Express callbacks turns out to be really handy. Since callbacks aren't possible in Express callbacks I opted to include it here. The use case where I need this is as follows:
- I have an object representing the current user attached to the request object
- The user has a name object consisting of first and last.
- I have a logout.html partial containing:
  
  <li>
    <a href="/users/{username}/settings">{name first} {name last}</a>
  </li>
  <li>
     <a class="logout" href="/logout">Logout</a>
  </li> 
  - With Y.substitute() it is a snap to substitute {name first} and {name last}. E.g:
    
    docY.substitute(partial('logout.html'), req.user, function(key, val, meta) {
        return key === 'name'
                ? val[meta]
                : val;
      })

I was also thinking that it might be of interest to add subFn to locals so that express.js would pass subFn to eY.substitute() making the power of a custom substitution function available there too.

What do you think?
