### PR TITLE
Fixed nodejs-node module dependency

### DIFF
--- a/lib/node-yui3.js
+++ b/lib/node-yui3.js
@@ -90,6 +90,7 @@ YUI.GlobalConfig = {
             }
         },
         'nodejs-node': {
+            requires: ['node'],
             fullpath: __dirname + '/node.js',
             condition: {
                 when: 'after',

--- a/lib/node.js
+++ b/lib/node.js
@@ -23,4 +23,4 @@ YUI.add('nodejs-node', function(Y) {
 
         return node;
     };
-});
+}, 'NODE', { requires: ['node'] });


### PR DESCRIPTION
Hi Dav!

Using 'npm install yui3' I noticed that the nodejs-node requires the 'node' module, otherwise it fails if YUI().used alone...

What do you think?

Best Regards
Standa
