### PR TITLE
pre-processing markup string before Y.substitute to remove <style> and <script> tags

### DIFF
--- a/examples/express/express.js
+++ b/examples/express/express.js
@@ -4,7 +4,7 @@ var express = require('express'),
     YUI = require('yui3').YUI;
 
 
-YUI({ debug: false, filter: 'min' }).use('express', 'node', function(Y) {
+YUI({ debug: false, filter: 'debug' }).use('express', 'node', function(Y) {
 
     var app = express.createServer();
 
@@ -104,6 +104,17 @@ YUI({ debug: false, filter: 'min' }).use('express', 'node', function(Y) {
                 }
             }
         });
+    });
+    
+    app.get('/pre', YUI.express({render: 'index.html', locals: {}}), function(req, res){
+        res.sub({
+            above_content: 'This was inserted above the content.',
+            title: 'Title #1',
+            title2: 'Title #2',
+            title3: 'Title #3',
+            title4: 'Title #4'
+        });
+        res.send();
     });
 
     app.listen(3000);

--- a/examples/express/views/layout.html
+++ b/examples/express/views/layout.html
@@ -1,7 +1,38 @@
+<style>
+	h3 {
+		background: pink;
+	}
+</style>
+
 Above normal content
 <hr>
+
+<script>alert('hi');</script>
+
+{above_content}
 <div id="content">
 
 </div>
 <hr>
 Below normal content
+<style>
+	h2 {
+		background: yellow;
+	}
+</style>
+<script>
+	// this is a test to ensure I can put brackets in here
+	(function() {
+		
+		document.write('<p>a script tag below normal content did this</p>');
+		
+		/*
+		YUI({filter:"debug"}).use("*", function(Y) {     Y.Dali.Platform.init({
+	        debug: true,
+	        props: { proxyUrl: "/proxy" },
+	        mods: [{"props":{"ns":"mods_module1","type":"mods_module1","id":"mods_module1","model":{}},"state":{"view":"dalidefault"}},{"props":{"ns":"mods_module2","type":"mods_module2","id":"mods_module2","model":{}},"state":{"view":"dalidefault"}}]
+	    }, true);});
+		*/
+		
+	}());
+</script>

--- a/lib/yui3-express.js
+++ b/lib/yui3-express.js
@@ -54,8 +54,10 @@ YUI.add('express', function(Y) {
                     if (yConfig.render) {
                         res._ySend = res.send;
                         res.sub = function(sub, fn) {
-                            var html = this.Y.config.doc.outerHTML;
-                            html = this.Y.substitute(html, sub, fn, true);
+                            var html = this.Y.config.doc.outerHTML,
+                                extraction = _substituteStylesAndScripts(html);
+                            this.Y.mix(sub, extraction.sub);
+                            html = this.Y.substitute(extraction.string, sub, fn, true);
                             this.Y.config.doc.innerHTML = html;
                         };
                         res.send = function(str) {
@@ -86,6 +88,49 @@ YUI.add('express', function(Y) {
                 fn.call(this, req2, res2, next2, req);
             };
         }
+        
+        /**
+        * Extracts all <style> and <script> tags from a string and replaces them with tokens to be
+        * used by Y.substitute so the {{}} brackets within them aren't falsely identified as tokens
+        * by Y.substitue. 
+        * @returns Object with 2 props : "string" contains the new string with {tokens} inserted
+        *                              : sub object that can be used by Y.substitute to re-inject
+        *                                <styles> and <scripts>
+        */
+        function _substituteStylesAndScripts(s) {
+			var start = '<script', 
+				end = '/script>',
+				sStart = s.indexOf(start), 
+				sEnd,
+				injection,
+				count = 0,
+				token,
+				tokens = [],
+				result = {sub:{}};
+
+			extract('script');
+			extract('style');
+
+			function extract(type) {
+				start = '<' + type;
+				end = '/' + type + '>';
+				sStart = s.indexOf(start);
+				
+				while (sStart > 0) {
+					injection = 'token-' + count++;
+					sEnd = s.indexOf(end) + end.length;
+					token = s.substring(sStart, sEnd);
+					tokens.push(token);
+					s = s.substring(0, sStart) + '{' + injection + '}' + s.substr(sEnd);
+					result.sub[injection] = token;
+					sStart = s.indexOf(start);
+				}					
+			}
+			
+			result.string = s;
+			return result;
+		}
+		
     };
 
     /**


### PR DESCRIPTION
I altered a couple example files I was using as a testing ground. Feel free to review and ignore them.
