### PR TITLE
Support yui3.configure({}).useSync()

### DIFF
--- a/lib/node-yui3.js
+++ b/lib/node-yui3.js
@@ -1,4 +1,3 @@
-
 var getYUI = function(c) {
     var yui3 = require('./yui3-yui3');
     var YUI = yui3.configure(c);
@@ -17,39 +16,53 @@ var cleanCache = function() {
     }
 }
 
-exports.__defineGetter__('YUI', function() {
-    var YUI = getYUI();
+// YInterface allows these two to work:
+// var Y = yui3.useSync("io");
+// var Y = yui3.configure({core:"3.3.0"}).useSync("io");
+// See also: tests/interface.js
+
+function YInterface (config) {
+    this.config = config || {};
+}
+
+var interface = YInterface.prototype;
+
+interface.__defineGetter__('YUI', function() {
+    var YUI = getYUI(this.config);
     return YUI;
 });
-exports.sync = function() {
-    var YUI = getYUI();
+
+
+interface.sync = function() {
+    var YUI = getYUI(this.config);
     YUI.loadSync = true;
     return YUI();
 };
-exports.async = function() {
-    var YUI = getYUI();
+interface.async = function() {
+    var YUI = getYUI(this.config);
     YUI.loadSync = false;
     return YUI();
 };
 
-exports.useSync = function() {
-    var YUI = getYUI();
+interface.useSync = function() {
+    var YUI = getYUI(this.config);
     YUI.loadSync = true;
     var Y = YUI();
     return Y.use.apply(Y, arguments);
 }
 
-exports.use = function() {
-    var YUI = getYUI();
+interface.use = function() {
+    var YUI = getYUI(this.config);
     YUI.loadSync = false;
     var Y = YUI();
     return Y.use.apply(Y, arguments);
 }
 
-exports.configure = function(c) {
-    var YUI = getYUI(c);
-    return YUI;
+interface.configure = function (config) {
+    return new YInterface(config);
 };
+
+module.exports = new YInterface;
 
 /*
 process.on('uncaughtException', function (err) {

--- a/tests/interface.js
+++ b/tests/interface.js
@@ -1,0 +1,33 @@
+var assert = require("assert"),
+    yui3 = require("../lib/node-yui3");
+
+module.exports = {
+    "yui3.useSync" : function () {
+        var Y = yui3.useSync("loader");
+        assert.ok(Y.Loader);
+    },
+    "yui3.configure({}).useSync" : function () {
+        var Y = yui3.configure({}).useSync("loader");
+        assert.ok(Y.Loader);
+    },
+    "yui3.YUI" : function () {
+        var Y = yui3.YUI;
+        assert.ok(Y);
+        assert.isUndefined(Y.Loader);
+    },
+    "yui3.configure({}).YUI" : function () {
+        var Y = yui3.configure({}).YUI;
+        assert.ok(Y);
+        assert.isUndefined(Y.Loader);
+    },
+    "yui3.use" : function () {
+        yui3.use("loader", function (Y) {
+            assert.ok(Y.Loader);
+        });
+    },
+    "yui3.configure({}).use" : function () {
+        yui3.configure({}).use("loader", function (Y) {
+            assert.ok(Y.Loader);
+        });
+    }
+};


### PR DESCRIPTION
Previously, yui3.configure({}) returned a YUI instance. Instead, I'd like to use the interface provided by require("yui3") on the configured result of configure() so I can useSync() modules for a specific version of YUI.

This patch provides this behavior. See the commit description and unit test for more details.

Thanks! -Reid
