### PR TITLE
Don't process.exit on error, throw it instead

### DIFF
--- a/lib/yui3-yui3.js
+++ b/lib/yui3-yui3.js
@@ -54,8 +54,8 @@ exports.configure = function(c) {
         var yui3 = require('yui3-core' + c.core);
         var YUI = yui3.YUI;
     } catch (e) {
-        console.log('YUI3 Core package was not found; npm install yui3-core');
-        process.exit();
+        throw new Error('YUI3 Core package was not found; npm install yui3-core');
+        return;
     }
 
     try {


### PR DESCRIPTION
If yui3-core wasn't found, don't commit server suicide.
