### PR TITLE
Prevent require.paths from growing unnecessarily large

### DIFF
--- a/lib/yui3-yui3.js
+++ b/lib/yui3-yui3.js
@@ -312,8 +312,12 @@ exports.configure = function(c) {
                         dirName = '.';
                         fileName = 'remoteResource';
                     } else {
-                        require.paths.push(dirName);
+                        var found = require.paths.some(function (path) {
+                            return path == dirName;
+                        });
+                        if (!found) require.paths.push(dirName);
                     }
+
                     var _require = require, fn;
                     var mod = "(function(YUI) { var __dirname = '" + dirName + "'; "+
                         "var __filename = '" + fileName + "'; " +


### PR DESCRIPTION
If a path already exists in require.paths, don't add it again.

This pull request fixes the issue on HEAD, but doesn't fix Mocha 0.1.7pre since it's currently using 0.5.25. See reid/nodejs-yui3@ff23efb9df3a596bb2a3 for a 0.5.25 hotfix, which should be released on npm as 0.5.25a or similar.
