### PR TITLE
RLS sorted array should include sorted env modules.

### DIFF
--- a/lib/yui3-rls.js
+++ b/lib/yui3-rls.js
@@ -25,6 +25,7 @@ util.inherits(RLS, events.EventEmitter);
 var proto = {
     setup: function() {
         this.files = [];
+        this.sorted = [];
         this.data = {};
 
         this.grab = true;
@@ -40,6 +41,10 @@ var proto = {
     coreInModules: null,
     grab: null,
     inst: null,
+    // Sorted is a list of all modules that should be attached
+    // to the instance being returned. This includes modules
+    // and deps that would be in the config.env and config.m.
+    sorted: null,
     normalizeConfig: function() {
         //No config.m given, giving it a default
         if (!this.config.m) {
@@ -140,12 +145,14 @@ var proto = {
         //  to NOT grab the files until it's done
         if (this.config.env) {
             this.grab = false;
-            //Using the modules that are already on the page.
 
-            // XXX: Problem. The loader.sorted bit below may not
-            // contain some modules that are already on the page
-            // but need to be *attached* to the Y instance!
+            //Using the modules that are already on the page.
             this.inst.useSync.apply(this.inst, this.config.env);
+
+            // If Loader is here (it may not be), add these modules to the sorted list.
+            if (this.inst.Env._loader && this.inst.Env._loader.sorted) {
+                this.sorted = this.sorted.concat(this.inst.Env._loader.sorted);
+            }
 
             this.grab = true;
         }
@@ -175,16 +182,14 @@ var proto = {
             }
         }
         if ((this.files.length && this.bootstrapCore) || this.coreInModules) {
-            //We are manually adding the seed, we need to fake loader since it may not be there..
-            if (!this.inst.Env._loader) {
-                this.inst.Env._loader = {};
-            }
-            if (!this.inst.Env._loader.sorted) {
-                this.inst.Env._loader.sorted = [];
+            // If Loader is here (it may not be), add these modules to the sorted list.
+            // They will be concat'ed to any modules added from the config.env.
+            if (this.inst.Env._loader && this.inst.Env._loader.sorted) {
+                this.sorted = this.sorted.concat(this.inst.Env._loader.sorted);
             }
 
             //Manually add YUI to the sorted array, since we are manually adding it to the list.
-            this.inst.Env._loader.sorted.unshift('yui');
+            this.sorted.unshift('yui');
             this.files.unshift(this.YUI.GlobalConfig.base + 'yui/yui-min.js');
         }
         this.emit('adjustFiles');
@@ -221,16 +226,12 @@ var proto = {
         [].concat(this.files, this.inst.config._cssLoad).forEach(function(v) {
             d[v] = self.data[v];
         });
-        var sorted = [];
-        if (this.inst.Env && this.inst.Env._loader && this.inst.Env._loader.sorted) {
-            sorted = this.inst.Env._loader.sorted;
-        }
         //console.log(Y.Env._loader.moduleInfo);
         this.payload = {
             js : this.files,
             css : this.inst.config._cssLoad,
             d: d,
-            sorted : sorted,
+            sorted : this.sorted,
             Y: this.inst
         };
         this.emit('complete');

--- a/tests/interface.js
+++ b/tests/interface.js
@@ -436,6 +436,27 @@ suite.add( new YUITest.TestCase({
             Assert.areEqual(13, data.js.length, 'Not enough files returned');
             next();
         });
+    }),
+    "rls node, dial in m with dial in env should include node in sorted": async(function(data, next) {
+        yui3.rls({
+            m: 'node,dial',
+            env: 'node',
+            v: '3.3.0'
+        }, function(err, data) {
+            Assert.isArray(data.js);
+            // Node should not be in the JavaScript returned.
+            Assert.isFalse(data.js.some(function(file) {
+                return file.indexOf('node-') !== -1;
+            }));
+            // Node is required for dial to work correctly.
+            // We should include node (and its deps)
+            // in data.sorted, but we don't need the files
+            // since it's already on the page.
+            Assert.isTrue(data.sorted.some(function(module) {
+                return module === 'node'
+            }));
+            next();
+        });
     })
 }));
 


### PR DESCRIPTION
Example: We ask for the modules and files needed for:
 m : ["node", "dial"]
 env : ["node"]

We should provide the files for dial only, since dial is
already on the page. However, the Y instance also requires
node and its dependencies attached. Therefore, we now
include these deps in the sorted list for attachment.

Ran `make test`, all tests pass.
