### PR TITLE
Error in latest jsdom (0.2.5)

### DIFF
--- a/lib/yui3-dom.js
+++ b/lib/yui3-dom.js
@@ -8,7 +8,7 @@ YUI.add('nodejs-dom', function(Y) {
 
     var jsdom = null,
         browser = {}, dom;
-    
+
     if (!YUI._jsdom) {
         YUI._jsdom = YUI.require('jsdom');
     }
@@ -22,9 +22,9 @@ YUI.add('nodejs-dom', function(Y) {
         FetchExternalResources: [], 
         ProcessExternalResources : false
     }
-    browser.window = jsdom.jsdom('', null, {features: features}).createWindow();
-    browser.document = browser.window.document;
-    
+    browser.document = jsdom.jsdom('<html><head></head><body></body></html>', null, {features: features});
+    browser.window = browser.document.createWindow();
+
     // Setup an html doctype
     var doctype = new dom.DocumentType(browser.document, 'html');
     browser.document.doctype = doctype;
@@ -34,7 +34,7 @@ YUI.add('nodejs-dom', function(Y) {
 
     browser.document.scrollTop = browser.document.documentElement.scrollTop = browser.document.body.scrollTop = 0;
     browser.document.scrollLeft = browser.document.documentElement.scrollLeft = browser.document.body.scrollLeft = 0;
-    
+
     browser.window.eval = eval;
 
     browser.self = browser.window;


### PR DESCRIPTION
document.getElementsByTagName("head") returns an empty array. 
- Added contents to the html document. Avoids error in jsdom 0.2.5 not being able to get element head
