### PR TITLE
Dependencies should be more specific

### DIFF
--- a/packages/bare-package.json
+++ b/packages/bare-package.json
@@ -2,9 +2,9 @@
     "name": "yui3-bare",
     "description": "YUI 3 Library on NodeJS - Bare - No Dependencies - Only install if you know what you are doing.",
     "devDependencies": {
-        "yui3-core": ">=3.4.0",
-        "jsdom": ">=0.1.23", 
-        "htmlparser": ">=1.7.3",
+        "yui3-core": "3.4.x",
+        "jsdom": "0.1.23 - 0.2.7", 
+        "htmlparser": "1.7.3",
         "yuitest" : "*"
     }
 }

--- a/packages/base-package.json
+++ b/packages/base-package.json
@@ -2,11 +2,11 @@
     "name": "yui3-base",
     "description": "YUI 3 Library on NodeJS - Base - Includes yui3-core dependency - NO DOM SUPPORT",
     "dependencies": {
-        "yui3-core": ">=3.4.0"
+        "yui3-core": "3.4.x"
     },
     "devDependencies": {
-        "jsdom": ">=0.1.23", 
-        "htmlparser": ">=1.7.3",
+        "jsdom": "0.1.23 - 0.2.7", 
+        "htmlparser": "1.7.3",
         "yuitest" : "*"
     }
 }

--- a/packages/full-package.json
+++ b/packages/full-package.json
@@ -2,9 +2,9 @@
     "name": "yui3",
     "description": "YUI 3 Library on NodeJS - Full Install - All dependencies",
     "dependencies": {
-        "yui3-core": ">=3.4.0",
-        "jsdom": ">=0.1.23", 
-        "htmlparser": ">=1.7.3"
+        "yui3-core": "3.4.x",
+        "jsdom": "0.1.23 - 0.2.7", 
+        "htmlparser": "1.7.3"
     },
     "devDependencies": {
         "yuitest" : "*"


### PR DESCRIPTION
The package dependencies should be future-proofed. Since ">= X.Y.Z" tells npm to fetch the absolute latest version of the library, there will be trouble when breaking changes are introduced in the future.

"yui3-core":">=3.4.0"
"jsdom":">=0.1.23"
"htmlparser":">=1.7.3"

This was seen in older versions of nodejs-yui3, i.e., when jsdom changed the structure of documents that were created by passing the empty string as content (bug #16 in nodejs-yui3) and versions of nodejs-yui3 prior to that point (such as 0.5.34) broke.
