### PR TITLE
Fix bug: config.data in GET requests is serialized into the URL twice

### DIFF
--- a/lib/yui3-io.js
+++ b/lib/yui3-io.js
@@ -11,11 +11,6 @@ YUI.add('io-nodejs', function(Y) {
         https = YUI.require('https');
     }
 
-    var _concat = function(uri, data) {
-        uri += (uri.indexOf('?') === -1 ? '?' : '&') + data;
-        return uri;
-    };
-
     var NodeTransport = {
         id: 'nodejs',
         src: {
@@ -26,12 +21,10 @@ YUI.add('io-nodejs', function(Y) {
                 Y.io.xdrResponse('start', transactionObject, config);
                 
                 var urlInfo = url.parse(uri, parseQueryString=false),
-                    p = YUI.urlInfoPort(urlInfo);
+                    p = YUI.urlInfoPort(urlInfo),
+                    method = config.method ? config.method.toUpperCase() : 'GET',
+                    data = config.data;
                 
-                if (!config.method) {
-                    config.method = 'GET';
-                }
-                config.method = config.method.toUpperCase();
                 if (!config.headers) {
                     config.headers = {};
                 }
@@ -44,25 +37,26 @@ YUI.add('io-nodejs', function(Y) {
                 if (urlInfo.search) {
                     req_url += urlInfo.search;
                 }
-                if (config.data) {
-                    if (Y.Lang.isObject(config.data) && Y.QueryString) {
+                if (data) {
+                    if (Y.Lang.isObject(data) && Y.QueryString) {
                         Y.log('Converting config.data Object to String', 'info', 'io');
-                        config.data = Y.QueryString.stringify(config.data);
+                        data = Y.QueryString.stringify(data);
                     }
-                    switch (config.method) {
+                    switch (method) {
                         case 'GET':
                         case 'HEAD':
                         case 'DELETE':
-                            req_url = _concat(req_url, config.data);
-                            config.data = '';
-                            Y.log('HTTP' + config.method + ' with data.  The querystring is: ' + uri, 'info', 'io');
+                            // The data object was serialized into the query
+                            // string by send() in io-base.
+                            data = '';
+                            Y.log('HTTP' + method + ' with data.  The querystring is: ' + uri, 'info', 'io');
                             break;
                         case 'POST':
                         case 'PUT':
                             // If Content-Type is defined in the configuration object, or
                             // or as a default header, it will be used instead of
                             // 'application/x-www-form-urlencoded; charset=UTF-8'
-                            config.headers['Content-Length'] = config.data.length;
+                            config.headers['Content-Length'] = data.length;
                             config.headers = Y.merge({
                                 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
                             }, config.headers);
@@ -70,7 +64,7 @@ YUI.add('io-nodejs', function(Y) {
                     }
                 }
 
-                Y.log('Requesting (' + config.method + '): ' + urlInfo.hostname, 'info', 'nodeio');
+                Y.log('Requesting (' + method + '): ' + urlInfo.hostname, 'info', 'nodeio');
                 if (http.get) { //0.4.0
                     Y.log('Using new 0.4.0 http.request', 'info', 'nodeio');
                     var h = ((urlInfo.protocol === 'https') || p === 443) ? https : http;
@@ -81,14 +75,14 @@ YUI.add('io-nodejs', function(Y) {
                     var request = h.request({
                         host: urlInfo.hostname,
                         port: p,
-                        method: config.method,
+                        method: method,
                         path: req_url,
                         headers: config.headers
                     });
                     var s = request;
                 } else {
                     var host = http.createClient(p, urlInfo.hostname, ((p === 443) ? true : false));
-                    var request = host.request(config.method, req_url, config.headers);
+                    var request = host.request(method, req_url, config.headers);
                     var s = request.socket || request;
                 }
                 Y.log('URL: ' + req_url, 'info', 'nodeio');
@@ -163,8 +157,8 @@ YUI.add('io-nodejs', function(Y) {
                     });
 
                 });
-                if (config.method !== 'GET') {
-                    request.write(config.data);
+                if (data) {
+                    request.write(data);
                 }
                 if (request.end) {
                     request.end();


### PR DESCRIPTION
Serialize data into the URL once. Avoid modifying config.data and config.method within send()
## Test Case

Without this patch, the YUI logs show how the URL has the GET data on it twice for the following example:

info: (nodeio): URL: /?a=1&b=2&a=1&b=2

server.js

<pre>
var http = require('http');
http.createServer(function (req, res) {
    console.warn(req.url);
    res.writeHead(200, {'Content-Type': 'text/plain'});
    res.end('Hello World\n');
}).listen(8080, "127.0.0.1");
console.log('Server running at http://127.0.0.1:8080/');
</pre>


client.js

<pre>
var YUI = require("yui3").YUI;

YUI().use('io', function(Y) {
    Y.io("http://localhost:8080/", {
        method: 'get',
        data: {a: 1, b: 2}
    });
});
</pre>
